### PR TITLE
Diverse Bugfixes

### DIFF
--- a/components/vga-adapter/capture.c
+++ b/components/vga-adapter/capture.c
@@ -200,6 +200,13 @@ void IRAM_ATTR capture_task(void*)
 
 		uint32_t line = next[3];
 
+		// _STATIC_SYS_VALS liegt jetzt im externen Flash-Rom - für die Kopierschleife etwas zu langsam
+		uint8_t colors[4];
+		for (int i=0;i<4;i++)
+		{
+			colors[i] = _STATIC_SYS_VALS[ACTIVESYS].colors[i];
+		}
+
 		// und nun die Pixel in den VGA-Puffer kopieren
 		if (sync>0 && line>=ABG_START_LINE && line<=ABG_START_LINE+399)
 		{
@@ -207,7 +214,7 @@ void IRAM_ATTR capture_task(void*)
             uint8_t* vgapos = (uint8_t*)((line - ABG_START_LINE)*640 + (int)VGA_BUF);
             for (int i=0;i<640;i++)
             {
-                *vgapos = _STATIC_SYS_VALS[ACTIVESYS].colors[(*bufpos) & 3];
+                *vgapos = colors[(*bufpos) & 3];
                 vgapos++;
                 bufpos+=PIXEL_STEP_LIST[i];
             }

--- a/components/vga-adapter/highint5.S
+++ b/components/vga-adapter/highint5.S
@@ -20,8 +20,8 @@ xt_highint5:
     s32i    a13, a0, 8
     s32i    a12, a0, 12
 
-    // DEBUG auf GPIO20
-    movi    a14, (1 << 14)      // Pin 14
+    // DEBUG auf GPIO14
+    movi    a14, (1 << 14)      // GPIO 14
     movi    a13, GPIO_OUT_W1TS_REG
     s32i    a14, a13, 0         // auf High
     // DEBUG Ende
@@ -36,7 +36,7 @@ xt_highint5:
     int i = 48;
     while (gpio_get_level(PIN_NUM_ABG_BSYNC2)!=0 && i>0) i--;
 */
-    movi    a12, 48                                // Timeout-Counter (~10µs)
+    movi    a12, 100                                // Timeout-Counter (~10µs)
 xt_highint5_L2:
     l32i    a13, a14, 0                             // GPIO's lesen
     and     a13, a13, a15
@@ -163,6 +163,12 @@ xt_highint5_L9:
     movi    a15, SYNC_BIT_VAL
     s32i    a15, a14, 0                             // gpio interrupt quittieren
     memw
+
+    // DEBUG auf GPIO14
+    movi    a14, (1 << 14)      // GPIO 14
+    movi    a13, GPIO_OUT_W1TS_REG
+    s32i    a14, a13, 4         // auf Low
+    // DEBUG Ende
 
     l32i    a15, a0, 0                              // Register wiederherstellen
     l32i    a14, a0, 4

--- a/components/vga-adapter/include/capture.h
+++ b/components/vga-adapter/include/capture.h
@@ -2,4 +2,4 @@
 #include <esp_heap_caps.h>
 
 void setup_abg();
-void IRAM_ATTR capture_task(void*);
+void capture_task(void*);

--- a/components/vga-adapter/include/main.h
+++ b/components/vga-adapter/include/main.h
@@ -1,3 +1,3 @@
 #pragma once
 
-void func(void);
+#define DEBUG 1

--- a/components/vga-adapter/include/osd.h
+++ b/components/vga-adapter/include/osd.h
@@ -6,4 +6,4 @@ bool restore_settings();
 bool write_settings();
 void switch_system();
 
-extern void IRAM_ATTR osd_task(void*);
+extern void osd_task(void*);

--- a/components/vga-adapter/include/pins.h
+++ b/components/vga-adapter/include/pins.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "main.h"
+
 // Pin-Definition --> muss gegebenenfalls auf die Schaltung angepasst wereden!
 #define PIN_NUM_VGA_R0 4
 #define PIN_NUM_VGA_R1 5

--- a/components/vga-adapter/main.c
+++ b/components/vga-adapter/main.c
@@ -5,8 +5,6 @@
 #include <rom/ets_sys.h>
 #include <soc/periph_defs.h>
 
-#define DEBUG 1
-
 #include "globalvars.h"
 #include "main.h"
 #include "osd.h"

--- a/components/vga-adapter/osd.c
+++ b/components/vga-adapter/osd.c
@@ -224,7 +224,7 @@ void switch_system() {
 }
 
 // das OSD-Menue
-void IRAM_ATTR osd_task(void*)
+void osd_task(void*)
 {
 	// Taster-Pins einstellen
 	gpio_config_t pincfg =


### PR DESCRIPTION
- DEBUG-Definition in die main.h verschoben, und diese in die pins.h included - sonst sind die DEBUG-GPIO's aus
- Debug-GPIO im ISR am Ende wieder aus - und Typo Fix
- IRAM_ATTR aus den Header-Definitionen entfernt, dadurch keine Kompiler-Warnungen mehr
- IRAM_ATTR vom osd_task entfernt - brauchen wir da nicht
- Bugfix capture_task: die color-Tabelle vor der Pixelkopierschleife in eine lokale Variable kopieren - es gibt sonst Performance-Probleme