### PR TITLE
nen ganzer Haufen Änderungen...

### DIFF
--- a/components/vga-adapter/globalvars.c
+++ b/components/vga-adapter/globalvars.c
@@ -8,25 +8,43 @@
 const struct SYSSTATIC _STATIC_SYS_VALS[] = {
 	{ 
 		.name = "A7100 ",
-		.colors = {0, 0b00000100, 0b00001000, 0b00001100},
+		.colors = {0, 0b00000100, 0b00001000, 0b00001100}, // 0b--rrggbb
+		.bits_per_sample = 8,
+		.xres = 640,
+		.yres = 400,
+		.interleave_mask = 0,
+		.default_pixel_abstand = 9010,
+		.default_start_line = 29,
+		.default_pixel_per_line = 73600,
 	},
 	{ 
 		.name = "PC1715",
 		.colors = {0b00001000, 0b00000100, 0, 0b00001100}, // 0b--rrggbb
+		.bits_per_sample = 4,
+		.xres = 640,
+		.yres = 400,
+		.interleave_mask = 0,
+		.default_pixel_abstand = 15567 /* schwankt bis auf 15588 */,
+		.default_start_line = 6,
+		.default_pixel_per_line = 86410,
+	},
+	{ 
+		.name = "EC1834",
+		.colors = {0, 0b00000100, 0b00001000, 0b00001100}, // 0b--rrggbb
+		.bits_per_sample = 8,
+		.xres = 720,
+		.yres = 350,
+		.interleave_mask = 0,
+		.default_pixel_abstand = 9010,     // Platzhalter, reale Parameter ermitteln!
+		.default_start_line = 29,          // Platzhalter, reale Parameter ermitteln!
+		.default_pixel_per_line = 73600,   // Platzhalter, reale Parameter ermitteln!
 	}
-};
-
-// Initialisierte Daten aus dem NVS - Werte, die durch den Anwender geändert werden können
-// Standardwerte für Modusinitialisierung nach Umschaltung des Modus
-const struct SYSVARS _DEFAULT_SYS_VARS[] = {
-	{.mode = 0, .pixel_abstand = 90.10f, .start_line = 29, .pixel_per_line = 736}, // A7100
-	{.mode = 1, .pixel_abstand = 155.67f /* schwankt bis auf 155.88 */, .start_line = 6, .pixel_per_line = 864.1} // PC1715
 };
 
 // globale Variablen
 
 // Aktives System
-uint16_t ACTIVESYS = ZIELTYP-1;
+uint16_t ACTIVESYS = 0;
 nvs_handle_t sys_nvs_handle;
 volatile uint32_t* ABG_DMALIST;
 volatile uint32_t ABG_Scan_Line = 0;
@@ -34,7 +52,11 @@ volatile double ABG_PIXEL_PER_LINE;
 volatile double BSYNC_PIXEL_ABSTAND;
 volatile uint32_t ABG_START_LINE;
 volatile bool ABG_RUN = false;
+uint32_t ABG_Interleave_Mask = 0;
 uint32_t ABG_Interleave = 0;
+uint16_t ABG_XRes = 0;
+uint16_t ABG_YRes = 0;
+uint8_t ABG_Bits_per_sample = 0;
 
 int BSYNC_SUCHE_START = 0;
 uint8_t* PIXEL_STEP_LIST;

--- a/components/vga-adapter/highint5.S
+++ b/components/vga-adapter/highint5.S
@@ -82,7 +82,8 @@ xt_highint5_L5:
     l32i    a13, a15, 0
     bnez    a14, xt_highint5_L11                    // Wenn Scanline==0, dann Interleave-Zähler+1
     addi    a13, a13, 1
-    movi    a12, INTERLEAVE_MASK
+    movi    a12, ABG_Interleave_Mask
+    l32i    a12, a12, 0
     and     a13, a13, a12
     s32i    a13, a15, 0
 
@@ -92,7 +93,8 @@ xt_highint5_L5:
 xt_highint5_L11:
     addi    a14, a14, 1                             // Scanline++
 
-    movi    a12, INTERLEAVE_MASK
+    movi    a12, ABG_Interleave_Mask
+    l32i    a12, a12, 0
     and     a15, a14, a12
     bne     a13, a15, xt_highint5_L3                // wenn Interleave-Zähler != Scanline --> Ende
 

--- a/components/vga-adapter/include/globalvars.h
+++ b/components/vga-adapter/include/globalvars.h
@@ -4,40 +4,29 @@
 #include "nvs_flash.h"
 #include "nvs.h"
 
-// Computer Typen
-#define A7100 1
-#define PC1715 2
-
-#define ZIELTYP A7100
-
-// Deklaration der Modi
-
 // Statische Struktur - Systemkonstanten
 struct SYSSTATIC {
 	char* name;
 	uint8_t colors[4];
+	uint8_t bits_per_sample; // 4 oder 8
+	uint16_t xres; // 640 oder 720
+	uint16_t yres;
+	uint8_t interleave_mask; // 	0=1:1	1=1:2	3=1:4
+	uint32_t default_pixel_abstand;
+	uint32_t default_start_line;
+	uint32_t default_pixel_per_line;
 };
 
 // Statische Werte vorinitialisiert
 extern const struct SYSSTATIC _STATIC_SYS_VALS[];
 
-// Modusstruktur - Systemvariablen, änderbar durch den Anwender
-struct SYSVARS {
-	uint16_t mode;
-	float pixel_abstand;
-	uint32_t start_line;
-	float pixel_per_line;
-};
-
-// Initialisierte Daten aus dem NVS - Werte, die durch den Anwender geändert werden können
-// Standardwerte für Modusinitialisierung nach Umschaltung des Modus
-extern const struct SYSVARS _DEFAULT_SYS_VARS[];
-
 // Bezeichner für NVS KEY - max 15 Zeichen!
 #define _NVS_SETTING_MODE	"SMODE"
-#define _NVS_SETTING_PIXEL_ABSTAND "SPIXABST"
-#define _NVS_SETTING_START_LINE	"SSTARTLINE"
-#define _NVS_SETTING_PIXEL_PER_LINE "SPIXPERLINE"
+#define _NVS_SETTING_PIXEL_ABSTAND "SPIXABST(%d)"
+#define _NVS_SETTING_START_LINE	"SSTARTLINE(%d)"
+#define _NVS_SETTING_PIXEL_PER_LINE "SPIXPERLINE(%d)"
+
+#define _SETTINGS_COUNT 3 // Anzahl unterstützter Computer = 3 (A7100,PC1715,EC1835)
 
 // globale Variablen
 
@@ -52,6 +41,11 @@ extern volatile double ABG_PIXEL_PER_LINE;
 extern volatile double BSYNC_PIXEL_ABSTAND;
 extern volatile uint32_t ABG_START_LINE;
 extern volatile bool ABG_RUN;
+extern uint32_t ABG_Interleave_Mask;
+extern uint32_t ABG_Interleave;
+extern uint16_t ABG_XRes;
+extern uint16_t ABG_YRes;
+extern uint8_t ABG_Bits_per_sample;
 
 extern int BSYNC_SUCHE_START;
 extern uint8_t* PIXEL_STEP_LIST;

--- a/components/vga-adapter/include/main.h
+++ b/components/vga-adapter/include/main.h
@@ -2,4 +2,3 @@
 
 // Build-Optionen
 #define DEBUG 1
-#define INTERLEAVE_MASK 3	// 0=1:1	1=1:2	3=1:4

--- a/components/vga-adapter/include/osd.h
+++ b/components/vga-adapter/include/osd.h
@@ -3,7 +3,6 @@
 
 void setup_flash();
 bool restore_settings();
-bool write_settings();
-void switch_system();
+bool write_settings(bool full);
 
 extern void osd_task(void*);

--- a/components/vga-adapter/main.c
+++ b/components/vga-adapter/main.c
@@ -16,13 +16,11 @@
 // Hauptprogramm
 void IRAM_ATTR app_main(void)
 {
-	setup_vga();
 	setup_flash();
-	// Standardwerte initialisieren
-	switch_system();
 	// NVS Einstellungen laden, wenn vorhanden
 	restore_settings();
 
+	setup_vga();
 	xTaskCreatePinnedToCore(osd_task,"osd_task",6000,NULL,0,NULL,0);
 	xTaskCreatePinnedToCore(capture_task,"capture_task",6000,NULL,10,NULL,1);
 }

--- a/components/vga-adapter/vga.c
+++ b/components/vga-adapter/vga.c
@@ -31,15 +31,15 @@ void setup_vga()
         {
         	// Timing von 800x600 70Hz VGA. Andere Auflösungen geben kein stabiles Bild.
             .pclk_hz = 40000000,  		// 40MHz Pixelfrequenz
-            .h_res = 640, 				// 800 auf VGA
-            .v_res = 420, 				// 600 auf VGA
+            .h_res = ABG_XRes, 			// 800 auf VGA
+            .v_res = ABG_YRes+20,   	// 600 auf VGA
 			//line
-            .hsync_back_porch = 88+80,  // 80 Pixel Rand (800-640)/2
-            .hsync_front_porch = 40+80, // 80 Pixel Rand (800-640)/2
+            .hsync_back_porch = 88+((800-ABG_XRes)/2),
+            .hsync_front_porch = 40+((800-ABG_XRes)/2),
             .hsync_pulse_width = 128,
 			//frame
-            .vsync_back_porch = 23+80, // 80 Pixel Rand (600-400)/2 (-20 für osd)
-            .vsync_front_porch = 1+100, // 100 Pixel Rand (600-400)/2
+            .vsync_back_porch = 23+((600-ABG_YRes)/2)-20,
+            .vsync_front_porch = 1+((600-ABG_YRes)/2),
             .vsync_pulse_width = 4,
 			.flags.hsync_idle_low = 1,
 			.flags.vsync_idle_low = 1,
@@ -52,5 +52,5 @@ void setup_vga()
     ESP_ERROR_CHECK(esp_lcd_panel_reset(VGA_Handle));
     ESP_ERROR_CHECK(esp_lcd_panel_init(VGA_Handle));
     esp_lcd_rgb_panel_get_frame_buffer(VGA_Handle, 1, (void*)&OSD_BUF); // der OSD-Buffer ist genaugenommen der gesamte Bildschirm
-    VGA_BUF = 20 * 640 + OSD_BUF;  // der Bereich für das eigendliche Bild beginnt erst ab Zeile 20
+    VGA_BUF = 20 * ABG_XRes + OSD_BUF;  // der Bereich für das eigendliche Bild beginnt erst ab Zeile 20
 }


### PR DESCRIPTION
- SPI/VGA Initialisierung mit verschiedenen Parametersätzen (4 oder 8 Bit Samples)
- entsprechende Auswahl der Kopierschleife
- Interleave ist als Parameter aktivierbar (von den 3 Computern braucht das aber keiner)
- mehrere Auflösungen möglich (720x350 für EC1834)
- Pfeil-Symbole für OSD-Menü
- OSD-Menü kann nun auch die Default-Einstellungen laden (Achtung, geänderte Menüstruktur!)
- bei Änderung des Computer-Typs erfolgt ein Reboot, damit die geänderten SPI/VGA-Parameter aktiv werden können
- die Einstellungen werden nun für jeden Computer-Typ getrennt gespeichert, beim Wechsel werden die gespeicherten Parameter geladen, wenn keine da sind dann default